### PR TITLE
Correção sugerida pela Maxipago na recorrencia e Codigo do SSL

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -458,8 +458,8 @@ $merchant = new Merchant("store-id", "token");
 //Crie seu cliente da SDK
 $maxipago = new MaxipagoClient($merchant, Environment::sandbox());
 
-$sale = (new Sale())->setProcessorID(1)->setReferenceNum("IdPedidoNaLoja")
-    ->setFraudCheck(false)->setIpAddress("189.38.95.95")
+$sale = (new RecurringPayment())->setProcessorID(1)->setReferenceNum("IdPedidoNaLoja")
+    ->setIpAddress("189.38.95.95")
     ->setCustomerIdExt('123.456.789-09');
 
 $customer = $sale->billingCustomer()->setName("Fulano da Silva")->setAddress("Rua das Fiandeiras, 123")

--- a/src/Gateway/Requests/AbstractRequest.php
+++ b/src/Gateway/Requests/AbstractRequest.php
@@ -56,7 +56,7 @@ abstract class AbstractRequest
             'defaults' => [
                 'config' => [
                     'curl' => [
-                        CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1_2
+                        CURLOPT_SSLVERSION => 6
                     ]
                 ]
             ]


### PR DESCRIPTION
Na recorrência a Maxipago recomendou retirar o "setFraudCheck" e com o new Sale() não funcionava, e sim o RecurringPayment()